### PR TITLE
Return null if OwnerClassName doesn't exist

### DIFF
--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -198,6 +198,9 @@ class ElementalArea extends DataObject
 
         if ($this->OwnerClassName) {
             $class = $this->OwnerClassName;
+            if (!ClassInfo::exists($class)) {
+                return null;
+            }
             $instance = Injector::inst()->get($class);
             if (!ClassInfo::hasMethod($instance, 'getElementalRelations')) {
                 return null;

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -196,11 +196,8 @@ class ElementalArea extends DataObject
             return $this->cacheData['owner_page'];
         }
 
-        if ($this->OwnerClassName) {
+        if ($this->OwnerClassName && ClassInfo::exists($this->OwnerClassName)) {
             $class = $this->OwnerClassName;
-            if (!ClassInfo::exists($class)) {
-                return null;
-            }
             $instance = Injector::inst()->get($class);
             if (!ClassInfo::hasMethod($instance, 'getElementalRelations')) {
                 return null;


### PR DESCRIPTION
Fixes an issue where elements won't load if they belong to a page type that has been removed.